### PR TITLE
Added retry for failed name lookups

### DIFF
--- a/ubderdownload.py
+++ b/ubderdownload.py
@@ -14,8 +14,6 @@ def get_page_with_wait(url, wait=6):  # SGF throttling is 10/minute
     if wait < 0.01:
         wait = 0.01
 
-    print(time.time(), wait, current_retry)
-
     try:
         time.sleep(wait)
         response = urllib2.urlopen(url)

--- a/ubderdownload.py
+++ b/ubderdownload.py
@@ -7,8 +7,15 @@ import os.path
 import traceback
 
 def get_page_with_wait(url, wait=6):  # SGF throttling is 10/minute
-    if wait <= 0:
+    global request_successful
+    global max_retries
+    global current_retry
+
+    if wait < 0.01:
         wait = 0.01
+
+    print(time.time(), wait, current_retry)
+
     try:
         time.sleep(wait)
         response = urllib2.urlopen(url)
@@ -18,8 +25,20 @@ def get_page_with_wait(url, wait=6):  # SGF throttling is 10/minute
             # exponential falloff
             return get_page_with_wait(url, wait=(1.5 * wait))
         raise
+    except urllib2.URLError as e:
+        if e.reason.errno == -2:  # Name or service not known
+            if request_successful:
+                if current_retry < max_retries:
+                    print("Address lookup error after success.  Trying again.")
+                    current_retry += 1
+                    return get_page_with_wait(url, 5)  # Wait 5 seconds between retries
+            print("Address lookup failing.  Check your network connection")
+            exit(1)
+        raise
     else:
         # everything is fine
+        current_retry = 0
+        request_successful = True
         return response.read()
 
 def results(url):
@@ -58,6 +77,10 @@ def save_sgf(out_filename, SGF_URL, name):
 if __name__ == "__main__":
     user_id = int(sys.argv[1])
     dest_dir = sys.argv[2]
+
+    request_successful = False
+    max_retries = 5
+    current_retry = 0
 
     if not os.path.exists(dest_dir):
         os.mkdir(dest_dir)


### PR DESCRIPTION
While getting my initial download, I had to restart the script a few times.  I figured to retry what appear to be soft errors.  If the first request fails, the user is still looking at the screen and this failure is most likely to be legitimate.

After a successful request, retry any future name lookup error
Default is set to 5 retries
Wait value on a retry is 5 seconds to give more time for temporary issues to clear

I also changed the test from "wait <= 0" to "wait < 0.01".  This is to account for any value smaller than the intended minimum.
